### PR TITLE
Added Puppeteer flags for heroku

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -76,7 +76,9 @@ export default class Parser {
             return cheerio.load(fs.readFileSync(file));
         } catch (error) {
             const url = `${baseUrl}/${type}/${resource}`;
-            const browser = await puppeteer.launch();
+            const browser = await puppeteer.launch({
+                args: ['--no-sandbox', '--disable-setuid-sandbox']
+            });
 
             const page = await browser.newPage();
             await page.goto(url);


### PR DESCRIPTION
According to [this](https://github.com/GoogleChrome/puppeteer/issues/758) page, Puppeteer needs some flags to run on Heroku.
Which is confirmed by [this](https://timleland.com/headless-chrome-on-heroku/) site.
